### PR TITLE
feat(haproxy_stats): add bind_addr variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The default values for the variables are set in `defaults/main.yml`:
 # Configure stats in HAProxy?
 haproxy_stats: yes
 haproxy_stats_port: 1936
+haproxy_stats_bind_addr: 0.0.0.0
 
 # Default setttings for HAProxy.
 haproxy_retries: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Configure stats in HAProxy?
 haproxy_stats: yes
 haproxy_stats_port: 1936
+haproxy_stats_bind_addr: 0.0.0.0
 
 # Default setttings for HAProxy.
 haproxy_retries: 3

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -16,6 +16,13 @@
       - haproxy_stats_port < 65536
     quiet: yes
 
+- name: test if haproxy_stats_bind_addr is set correctly
+  ansible.builtin.assert:
+    that:
+      - haproxy_stats_port is defined
+      - haproxy_stats_port is string
+    quiet: yes
+
 - name: test if haproxy_retries is set correctly
   ansible.builtin.assert:
     that:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -19,8 +19,8 @@
 - name: test if haproxy_stats_bind_addr is set correctly
   ansible.builtin.assert:
     that:
-      - haproxy_stats_port is defined
-      - haproxy_stats_port is string
+      - haproxy_stats_bind_addr is defined
+      - haproxy_stats_bind_addr is string
     quiet: yes
 
 - name: test if haproxy_retries is set correctly

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -29,7 +29,7 @@ defaults
 
 {% if haproxy_stats == true %}
 listen stats
-    bind                 :{{ haproxy_stats_port }}
+    bind                 {{haproxy_stats_bind_addr }}:{{ haproxy_stats_port }}
     mode                 http
     stats                enable
     stats                uri /stats


### PR DESCRIPTION

---
name: feat(haproxy_stats): add bind_addr
about: adds bind address to haproxy stats configuration

---

**Describe the change**
Enables us to be able to set a bind address in case we want the stats frontend to be reachable only via localhost or a special IP

**Testing**
I'll be able to test this change on a development server.

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
