### PR TITLE
Add custom 'custom_config' option for frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
           address: "*"
           port: 80
           default_backend: backend
+          # You can optionally set custom configuration here. This is useful for things like redirecting traffic based on the URL.
+          # custom_config: >
+          #   tcp-request inspect-delay 5s
+          #   acl my_blog hdr(host) -i blog.example.domain
+          #   use_backend backend if my_blog
         - name: https
           address: "*"
           port: 443

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -43,6 +43,7 @@ frontend {{ frontend.name }}
     default_backend {{ frontend.default_backend }}
     mode {{ frontend.mode | default('http') }}
     option {{ frontend.option | default('httplog') }}
+    {% if frontend.custom_config is defined %}{{ frontend.custom_config }}{% endif %}
 {% endfor %}
 {% for backend in haproxy_backends %}
 backend {{ backend.name }}


### PR DESCRIPTION
---
name: PR to add custom configuration options to frontend
about: Adds the ability to specify custom configuration to be included in frontend blocks. Useful for directing traffic based on host headers, and any other changes you might need to make.

---

**Describe the change**
Adds frontend.custom_config

**Testing**
Tested in https://github.com/riffcc/haproxy-cluster-playbook with a live set of 3 haproxies.
