### PR TITLE
feat: add support for http-response for frontends

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,6 +15,7 @@
           address: "*"
           port: 443
           default_backend: backend
+          http_response: set-header Strict-Transport-Security max-age=63072000
           ssl: true
           crts:
             - /tmp/haproxy.keycrt

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -144,6 +144,18 @@
       when:
         - item.http_request is defined
 
+    - name: assert | Test optional item http_response in haproxy_frontends
+      ansible.builtin.assert:
+        that:
+          - item.http_response is string
+          - item.http_response is not none
+        quiet: true
+      loop: "{{ haproxy_frontends }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when:
+        - item.http_response is defined
+
     - name: assert | Test optional item no_log in haproxy_frontends
       ansible.builtin.assert:
         that:

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -53,6 +53,9 @@ frontend {{ frontend.name }}
 {% if frontend.http_request is defined %}
     http-request {{ frontend.http_request }}
 {% endif %}
+{% if frontend.http_response is defined %}
+    http-response {{ frontend.http_response }}
+{% endif %}
 {% if frontend.no_log is defined and frontend.no_log %}
     no log
 {% endif %}


### PR DESCRIPTION
https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#4-http-response

---
name: add support for http-response for frontends
about: Add http_response config option

---

**Describe the change**
Adds support for the http-response option. This is used to e.g. add HSTS https://www.haproxy.com/blog/haproxy-and-http-strict-transport-security-hsts#configure-the-strict-transport-security-header

**Testing**
1. Molecule test
2. Roll out change in own environment and run `sudo haproxy -f /etc/haproxy/haproxy.cfg -c` after adding http_response config.
