### PR TITLE
feat: add support for custom global parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,15 @@ haproxy_stats_bind_addr: "0.0.0.0"
 
 # Default setttings for HAProxy.
 haproxy_mode: http
+haproxy_globals:
+  - log 127.0.0.1 local2
+  - chroot /var/lib/haproxy
+  - pidfile /var/run/haproxy.pid
+  - maxconn 4000
+  - user haproxy
+  - group haproxy
+  - daemon
+  - stats socket /var/lib/haproxy/stats
 haproxy_options:
   - httplog
   - dontlognull

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -15,6 +15,10 @@ argument_specs:
         type: "str"
         default: "http"
         description: "The default mode for HAProxy (http or tcp)."
+      haproxy_globals:
+        type: "list"
+        default: ['log 127.0.0.1 local2', 'chroot /var/lib/haproxy','pidfile /var/run/haproxy.pid','maxconn 4000','user haproxy','group haproxy','daemon','stats socket /var/lib/haproxy/stats']
+        description: "A list of glboal settings for HAProxy"
       haproxy_options:
         type: "list"
         default: ["httplog", "dontlognull", "http-server-close", "forwardfor except 127.0.0.0/8", "redispatch"]

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -20,6 +20,13 @@
           - haproxy_mode in [ "http", "tcp" ]
         quiet: true
 
+    - name: assert | Test haproxy_globals
+      ansible.builtin.assert:
+        that:
+          - haproxy_globals is defined
+          - haproxy_globals is iterable
+        quiet: true
+
     - name: assert | Test haproxy_options
       ansible.builtin.assert:
         that:

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -4,14 +4,9 @@
 {{ haproxy_config }}
 {% else %}
 global
-    log         127.0.0.1 local2
-    chroot      /var/lib/haproxy
-    pidfile     /var/run/haproxy.pid
-    maxconn     4000
-    user        haproxy
-    group       haproxy
-    daemon
-    stats       socket /var/lib/haproxy/stats
+{% for global in haproxy_globals %}
+    {{ global }}
+{% endfor %}
 
 defaults
     mode                    {{ haproxy_mode }}


### PR DESCRIPTION
---
name feat: add support for custom global parameters.
about: Adds support for custom global settings.

---

**Describe the change**
This adds support for custom global configuration paramters without needing to paste an entire HAProxy config.
https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#3

**Testing**
- molecule test
- Tested with intermediate config from https://ssl-config.mozilla.org/#server=haproxy&version=3.0&config=intermediate&openssl=3.4.0&guideline=5.7

