### PR TITLE
feat: add possibility to configure multiple bind addresses for frontends

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -30,6 +30,12 @@
           mode: http
           http_request: use-service prometheus-exporter
           no_log: true
+        - name: multi-address
+          address:
+            - "*"
+            - "::"
+          default_backend: backend
+          port: 8443
       haproxy_backend_default_balance: roundrobin
       haproxy_backends:
         - name: backend

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -103,7 +103,7 @@
           - item.name is string
           - item.name is not none
           - item.address is defined
-          - item.address is string
+          - item.address is string or (item.address is iterable and item.address is not mapping)
           - item.address is not none
           - item.port is defined
           - item.port is number
@@ -300,7 +300,7 @@
           - item.name is string
           - item.name is not none
           - item.address is defined
-          - item.address is string
+          - item.address is string or (item.address is iterable and item.address is not mapping)
           - item.address is not none
           - (item.balance is defined
             and item.balance is string

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -38,7 +38,9 @@ listen stats
 
 {% for frontend in haproxy_frontends %}
 frontend {{ frontend.name }}
-    bind {{ frontend.address }}:{{ frontend.port }}{% if frontend.ssl is defined and frontend.ssl == true %} ssl{% endif %}{% if frontend.crts is defined and frontend.crts | length > 0 %} {% for crt in frontend.crts %} crt {{ crt }}{% endfor %}{% endif %}
+{%- for address in (frontend.address if frontend.address is not string else [frontend.address]) +%}
+    bind {{ address }}:{{ frontend.port }}{% if frontend.ssl is defined and frontend.ssl == true %} ssl{% endif %}{% if frontend.crts is defined and frontend.crts | length > 0 %} {% for crt in frontend.crts %} crt {{ crt }}{% endfor %}{% endif %}
+{% endfor %}
 
 {% if frontend.default_backend is defined %}
     default_backend {{ frontend.default_backend }}
@@ -85,7 +87,9 @@ backend {{ backend.name }}
 
 {% for listen in haproxy_listens %}
 listen {{ listen.name }}
-    bind {{ listen.address }}:{{ listen.listen_port }}{% if listen.ssl is defined and listen.ssl == true %} ssl{% endif %}{% if listen.crts is defined and listen.crts | length >0 %}{% for crt in listen.crts %} crt {{ crt }}{% endfor %}{% endif %}
+{%- for address in (listen.address if listen.address is not string else [listen.address]) +%}
+    bind {{ address }}:{{ listen.listen_port }}{% if listen.ssl is defined and listen.ssl == true %} ssl{% endif %}{% if listen.crts is defined and listen.crts | length >0 %}{% for crt in listen.crts %} crt {{ crt }}{% endfor %}{% endif %}
+{% endfor %}
 
 {% if listen.httpcheck %}
     option httpchk {% if listen.httpcheck_method is defined %}{{ listen.httpcheck_method }}{% endif %}


### PR DESCRIPTION
---
name: feat: add possibility to configure multiple bind addresses for frontends
about: adds possibility to define multiple bind/listen addresses

---

**Describe the change**
This PR adds the possibility to add multiple bind/listen addresses. It's written in a way to be compatible to the current implementation of a single address as a string. [Haproxy Documentation](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/proxying-essentials/configuration-basics/frontends/#listen-on-multiple-ip-addresses-and-ports) for this feature.

**Testing**
- molecule tests
- manual tests
